### PR TITLE
Disable proto rule generation for bleve

### DIFF
--- a/deps.bzl
+++ b/deps.bzl
@@ -3,6 +3,7 @@ load("@bazel_gazelle//:deps.bzl", "go_repository")
 def go_dependencies():
     go_repository(
         name = "com_github_blevesearch_bleve_v2",
+        build_file_proto_mode = "disable",  # keep
         importpath = "github.com/blevesearch/bleve/v2",
         sum = "h1:1wuR7eB8Fk9UaCaBUfnQt5V7zIpi4VDok9ExN7Rl+/8=",
         version = "v2.3.5",


### PR DESCRIPTION
The bleve project generates their own golang code from their proto definition and doesn't need Bazel to generate it. This change disables proto rule generation for the bleve dependency so that the .pb.go file gets added to the sources for the upsidedown library within bleve. This allows the project to build successfully.